### PR TITLE
Missing or(|) in update and assign of register count

### DIFF
--- a/modbus/functions/mbfuncholding.c
+++ b/modbus/functions/mbfuncholding.c
@@ -182,7 +182,7 @@ eMBFuncReadHoldingRegister( UCHAR * pucFrame, USHORT * usLen )
         usRegAddress++;
 
         usRegCount = ( USHORT )( pucFrame[MB_PDU_FUNC_READ_REGCNT_OFF] << 8 );
-        usRegCount = ( USHORT )( pucFrame[MB_PDU_FUNC_READ_REGCNT_OFF + 1] );
+        usRegCount |= ( USHORT )( pucFrame[MB_PDU_FUNC_READ_REGCNT_OFF + 1] );
 
         /* Check if the number of registers to read is valid. If not
          * return Modbus illegal data value exception. 


### PR DESCRIPTION
Correct an error in the register count update. 

Falls Sie Deutsch bevorzuegen, kommentieren wir auf Deutsch.