### PR TITLE
eMBPoll: properly protect MB_ASCII mode checks

### DIFF
--- a/modbus/mb.c
+++ b/modbus/mb.c
@@ -395,10 +395,12 @@ eMBPoll( void )
                     ucMBFrame[usLength++] = ( UCHAR )( ucFunctionCode | MB_FUNC_ERROR );
                     ucMBFrame[usLength++] = eException;
                 }
+#if MB_ASCII_ENABLED > 0
                 if( ( eMBCurrentMode == MB_ASCII ) && MB_ASCII_TIMEOUT_WAIT_BEFORE_SEND_MS )
                 {
                     vMBPortTimersDelay( MB_ASCII_TIMEOUT_WAIT_BEFORE_SEND_MS );
                 }                
+#endif
                 eStatus = peMBFrameSendCur( ucMBAddress, ucMBFrame, usLength );
             }
             break;


### PR DESCRIPTION
If ascii mode is disabled, the unprotected checks cause compilation
failures.

Signed-off-by: Karl Palsson <karlp@etactica.com>