### PR TITLE
support variable stop bits

### DIFF
--- a/modbus/ascii/mbascii.c
+++ b/modbus/ascii/mbascii.c
@@ -104,7 +104,7 @@ static volatile UCHAR ucMBLFCharacter;
 
 /* ----------------------- Start implementation -----------------------------*/
 eMBErrorCode
-eMBASCIIInit( UCHAR ucSlaveAddress, UCHAR ucPort, ULONG ulBaudRate, eMBParity eParity )
+eMBASCIIInit( UCHAR ucSlaveAddress, UCHAR ucPort, ULONG ulBaudRate, eMBParity eParity, UCHAR ucStopBits )
 {
     eMBErrorCode    eStatus = MB_ENOERR;
     ( void )ucSlaveAddress;
@@ -112,7 +112,7 @@ eMBASCIIInit( UCHAR ucSlaveAddress, UCHAR ucPort, ULONG ulBaudRate, eMBParity eP
     ENTER_CRITICAL_SECTION(  );
     ucMBLFCharacter = MB_ASCII_DEFAULT_LF;
 
-    if( xMBPortSerialInit( ucPort, ulBaudRate, 7, eParity ) != TRUE )
+    if( xMBPortSerialInit( ucPort, ulBaudRate, 7, eParity, ucStopBits ) != TRUE )
     {
         eStatus = MB_EPORTERR;
     }

--- a/modbus/ascii/mbascii.h
+++ b/modbus/ascii/mbascii.h
@@ -36,7 +36,8 @@ PR_BEGIN_EXTERN_C
 
 #if MB_ASCII_ENABLED > 0
 eMBErrorCode    eMBASCIIInit( UCHAR slaveAddress, UCHAR ucPort,
-                              ULONG ulBaudRate, eMBParity eParity );
+                              ULONG ulBaudRate, eMBParity eParity,
+                              UCHAR ucStopBits );
 void            eMBASCIIStart( void );
 void            eMBASCIIStop( void );
 

--- a/modbus/include/mb.h
+++ b/modbus/include/mb.h
@@ -138,6 +138,7 @@ typedef enum
  * \param ulBaudRate The baudrate. E.g. 19200. Supported baudrates depend
  *   on the porting layer.
  * \param eParity Parity used for serial transmission.
+ * \param ucStopBits Number of stop bits for serial transmission.
  *
  * \return If no error occurs the function returns eMBErrorCode::MB_ENOERR.
  *   The protocol is then in the disabled state and ready for activation
@@ -148,7 +149,8 @@ typedef enum
  *    - eMBErrorCode::MB_EPORTERR IF the porting layer returned an error.
  */
 eMBErrorCode    eMBInit( eMBMode eMode, UCHAR ucSlaveAddress,
-                         UCHAR ucPort, ULONG ulBaudRate, eMBParity eParity );
+                         UCHAR ucPort, ULONG ulBaudRate, eMBParity eParity,
+                         UCHAR ucStopBits );
 
 /*! \ingroup modbus
  * \brief Initialize the Modbus protocol stack for Modbus TCP.

--- a/modbus/include/mbport.h
+++ b/modbus/include/mbport.h
@@ -68,7 +68,8 @@ BOOL            xMBPortEventGet(  /*@out@ */ eMBEventType * eEvent );
 /* ----------------------- Serial port functions ----------------------------*/
 
 BOOL            xMBPortSerialInit( UCHAR ucPort, ULONG ulBaudRate,
-                                   UCHAR ucDataBits, eMBParity eParity );
+                                   UCHAR ucDataBits, eMBParity eParity,
+                                   UCHAR ucStopBits );
 
 void            vMBPortClose( void );
 

--- a/modbus/mb.c
+++ b/modbus/mb.c
@@ -126,7 +126,8 @@ static xMBFunctionHandler xFuncHandlers[MB_FUNC_HANDLERS_MAX] = {
 
 /* ----------------------- Start implementation -----------------------------*/
 eMBErrorCode
-eMBInit( eMBMode eMode, UCHAR ucSlaveAddress, UCHAR ucPort, ULONG ulBaudRate, eMBParity eParity )
+eMBInit( eMBMode eMode, UCHAR ucSlaveAddress, UCHAR ucPort, ULONG ulBaudRate, eMBParity eParity,
+         UCHAR ucStopBits )
 {
     eMBErrorCode    eStatus = MB_ENOERR;
 
@@ -153,7 +154,7 @@ eMBInit( eMBMode eMode, UCHAR ucSlaveAddress, UCHAR ucPort, ULONG ulBaudRate, eM
             pxMBFrameCBTransmitterEmpty = xMBRTUTransmitFSM;
             pxMBPortCBTimerExpired = xMBRTUTimerT35Expired;
 
-            eStatus = eMBRTUInit( ucMBAddress, ucPort, ulBaudRate, eParity );
+            eStatus = eMBRTUInit( ucMBAddress, ucPort, ulBaudRate, eParity, ucStopBits );
             break;
 #endif
 #if MB_ASCII_ENABLED > 0
@@ -167,7 +168,7 @@ eMBInit( eMBMode eMode, UCHAR ucSlaveAddress, UCHAR ucPort, ULONG ulBaudRate, eM
             pxMBFrameCBTransmitterEmpty = xMBASCIITransmitFSM;
             pxMBPortCBTimerExpired = xMBASCIITimerT1SExpired;
 
-            eStatus = eMBASCIIInit( ucMBAddress, ucPort, ulBaudRate, eParity );
+            eStatus = eMBASCIIInit( ucMBAddress, ucPort, ulBaudRate, eParity, ucStopBits );
             break;
 #endif
         default:

--- a/modbus/rtu/mbrtu.c
+++ b/modbus/rtu/mbrtu.c
@@ -77,7 +77,8 @@ static volatile USHORT usRcvBufferPos;
 
 /* ----------------------- Start implementation -----------------------------*/
 eMBErrorCode
-eMBRTUInit( UCHAR ucSlaveAddress, UCHAR ucPort, ULONG ulBaudRate, eMBParity eParity )
+eMBRTUInit( UCHAR ucSlaveAddress, UCHAR ucPort, ULONG ulBaudRate, eMBParity eParity,
+            UCHAR ucStopBits )
 {
     eMBErrorCode    eStatus = MB_ENOERR;
     ULONG           usTimerT35_50us;
@@ -86,7 +87,7 @@ eMBRTUInit( UCHAR ucSlaveAddress, UCHAR ucPort, ULONG ulBaudRate, eMBParity ePar
     ENTER_CRITICAL_SECTION(  );
 
     /* Modbus RTU uses 8 Databits. */
-    if( xMBPortSerialInit( ucPort, ulBaudRate, 8, eParity ) != TRUE )
+    if( xMBPortSerialInit( ucPort, ulBaudRate, 8, eParity, ucStopBits ) != TRUE )
     {
         eStatus = MB_EPORTERR;
     }

--- a/modbus/rtu/mbrtu.h
+++ b/modbus/rtu/mbrtu.h
@@ -34,7 +34,7 @@
 PR_BEGIN_EXTERN_C
 #endif
     eMBErrorCode eMBRTUInit( UCHAR slaveAddress, UCHAR ucPort, ULONG ulBaudRate,
-                             eMBParity eParity );
+                             eMBParity eParity, UCHAR ucStopBits );
 void            eMBRTUStart( void );
 void            eMBRTUStop( void );
 eMBErrorCode    eMBRTUReceive( UCHAR * pucRcvAddress, UCHAR ** pucFrame, USHORT * pusLength );


### PR DESCRIPTION
The commonly required settings are not just baud and parity, but also
sometimes stop bits.  Add as an extra parameter to mbascii and mbrtu.

Signed-off-by: Karl Palsson <karlp@etactica.com>