### PR TITLE
allow ports to define included functions.

### DIFF
--- a/modbus/include/mbconfig.h
+++ b/modbus/include/mbconfig.h
@@ -95,34 +95,54 @@ PR_BEGIN_EXTERN_C
 #define MB_FUNC_OTHER_REP_SLAVEID_BUF           ( 32 )
 
 /*! \brief If the <em>Report Slave ID</em> function should be enabled. */
-#define MB_FUNC_OTHER_REP_SLAVEID_ENABLED       (  1 )
+#ifndef MB_FUNC_OTHER_REP_SLAVEID_ENABLED
+#define MB_FUNC_OTHER_REP_SLAVEID_ENABLED       ( 1 )
+#endif
 
 /*! \brief If the <em>Read Input Registers</em> function should be enabled. */
-#define MB_FUNC_READ_INPUT_ENABLED              (  1 )
+#ifndef MB_FUNC_READ_INPUT_ENABLED
+#define MB_FUNC_READ_INPUT_ENABLED              ( 1 )
+#endif
 
 /*! \brief If the <em>Read Holding Registers</em> function should be enabled. */
-#define MB_FUNC_READ_HOLDING_ENABLED            (  1 )
+#ifndef MB_FUNC_READ_HOLDING_ENABLED
+#define MB_FUNC_READ_HOLDING_ENABLED            ( 1 )
+#endif
 
 /*! \brief If the <em>Write Single Register</em> function should be enabled. */
-#define MB_FUNC_WRITE_HOLDING_ENABLED           (  1 )
+#ifndef MB_FUNC_WRITE_HOLDING_ENABLED
+#define MB_FUNC_WRITE_HOLDING_ENABLED           ( 1 )
+#endif
 
 /*! \brief If the <em>Write Multiple registers</em> function should be enabled. */
-#define MB_FUNC_WRITE_MULTIPLE_HOLDING_ENABLED  (  1 )
+#ifndef MB_FUNC_WRITE_MULTIPLE_HOLDING_ENABLED
+#define MB_FUNC_WRITE_MULTIPLE_HOLDING_ENABLED  ( 1 )
+#endif
 
 /*! \brief If the <em>Read Coils</em> function should be enabled. */
-#define MB_FUNC_READ_COILS_ENABLED              (  1 )
+#ifndef MB_FUNC_READ_COILS_ENABLED
+#define MB_FUNC_READ_COILS_ENABLED              ( 1 )
+#endif
 
 /*! \brief If the <em>Write Coils</em> function should be enabled. */
-#define MB_FUNC_WRITE_COIL_ENABLED              (  1 )
+#ifndef MB_FUNC_WRITE_COIL_ENABLED
+#define MB_FUNC_WRITE_COIL_ENABLED              ( 1 )
+#endif
 
 /*! \brief If the <em>Write Multiple Coils</em> function should be enabled. */
-#define MB_FUNC_WRITE_MULTIPLE_COILS_ENABLED    (  1 )
+#ifndef MB_FUNC_WRITE_MULTIPLE_COILS_ENABLED
+#define MB_FUNC_WRITE_MULTIPLE_COILS_ENABLED    ( 1 )
+#endif
 
 /*! \brief If the <em>Read Discrete Inputs</em> function should be enabled. */
-#define MB_FUNC_READ_DISCRETE_INPUTS_ENABLED    (  1 )
+#ifndef MB_FUNC_READ_DISCRETE_INPUTS_ENABLED
+#define MB_FUNC_READ_DISCRETE_INPUTS_ENABLED    ( 1 )
+#endif
 
 /*! \brief If the <em>Read/Write Multiple Registers</em> function should be enabled. */
-#define MB_FUNC_READWRITE_HOLDING_ENABLED       (  1 )
+#ifndef MB_FUNC_READWRITE_HOLDING_ENABLED
+#define MB_FUNC_READWRITE_HOLDING_ENABLED       ( 1 )
+#endif
 
 /*! @} */
 #ifdef __cplusplus


### PR DESCRIPTION
Instead of requiring the library itself to be modified to enable/disable
functions, allow the port layer to define what functions are included.
This makes maintennance of a common freemodbus core library simpler.

All functions retain their original defaults.

Signed-off-by: Karl Palsson <karlp@etactica.com>