### PR TITLE
eMBPoll: return internal failures

### DIFF
--- a/modbus/mb.c
+++ b/modbus/mb.c
@@ -407,5 +407,5 @@ eMBPoll( void )
             break;
         }
     }
-    return MB_ENOERR;
+    return eStatus;
 }


### PR DESCRIPTION
Status flags are returned by the internal peMBFrameReceiveCur and
peMBFrameSendCur handlers, but were being ignored, with the function
simply always returning MB_ENOERR unless the entire eMBState was
invalid.

This should allow better stats collecting from the outside of eMBPoll

Fixes: https://github.com/cwalter-at/freemodbus/issues/8
Signed-off-by: Karl Palsson <karlp@etactica.com>