### PR TITLE
Fixed bug related to lwIP TCP socket errors. When the lwIP Raw API

### DIFF
--- a/demo/MCF5235TCP/port/porttcp.c
+++ b/demo/MCF5235TCP/port/porttcp.c
@@ -211,7 +211,15 @@ prvvMBTCPPortError( void *pvArg, err_t xErr )
 #ifdef MB_TCP_DEBUG
         vMBPortLog( MB_LOG_DEBUG, "MBTCP-ERROR", "Error with client connection! Droping it.\r\n" );
 #endif
-        prvvMBPortReleaseClient( pxPCB );
+
+        if( pxPCB == pxPCBListen )
+        {
+            pxPCBListen = NULL;
+            
+#ifdef MB_TCP_DEBUG
+            vMBPortLog( MB_LOG_ERROR, "MBTCP-ERROR", "Error with listening connection!\r\n" );
+#endif
+        }
     }
 }
 

--- a/demo/STR71XTCP/port/porttcp.c
+++ b/demo/STR71XTCP/port/porttcp.c
@@ -213,7 +213,15 @@ prvvMBTCPPortError( void *pvArg, err_t xErr )
 #ifdef MB_TCP_DEBUG
         vMBPortLog( MB_LOG_DEBUG, "MBTCP-ERROR", "Error with client connection! Droping it.\r\n" );
 #endif
-        prvvMBPortReleaseClient( pxPCB );
+
+        if( pxPCB == pxPCBListen )
+        {
+            pxPCBListen = NULL;
+            
+#ifdef MB_TCP_DEBUG
+            vMBPortLog( MB_LOG_ERROR, "MBTCP-ERROR", "Error with listening connection!\r\n" );
+#endif
+        }
     }
 }
 


### PR DESCRIPTION
invokes the registerd 'tcp_err' handler, the socket is not
provided for a reason. After the error handler returns, lwIP frees
the TCP PCB object. If the error handler has already freed the TCP
PCB in the error handler, the TCP PCB pool within lwIP is tainted
and the lwIP stack will get stuck in an infinite loop.