### PR TITLE
Fix trivial compiler warnings.

### DIFF
--- a/modbus/ascii/mbascii.c
+++ b/modbus/ascii/mbascii.c
@@ -99,7 +99,6 @@ static volatile eMBBytePos eBytePos;
 static volatile UCHAR *pucSndBufferCur;
 static volatile USHORT usSndBufferCount;
 
-static volatile UCHAR ucLRC;
 static volatile UCHAR ucMBLFCharacter;
 
 /* ----------------------- Start implementation -----------------------------*/

--- a/modbus/rtu/mbcrc.c
+++ b/modbus/rtu/mbcrc.c
@@ -81,7 +81,7 @@ static const UCHAR aucCRCLo[] = {
 };
 
 USHORT
-usMBCRC16( UCHAR * pucFrame, USHORT usLen )
+usMBCRC16( const UCHAR * pucFrame, USHORT usLen )
 {
     UCHAR           ucCRCHi = 0xFF;
     UCHAR           ucCRCLo = 0xFF;

--- a/modbus/rtu/mbcrc.h
+++ b/modbus/rtu/mbcrc.h
@@ -30,6 +30,6 @@
 #ifndef _MB_CRC_H
 #define _MB_CRC_H
 
-USHORT          usMBCRC16( UCHAR * pucFrame, USHORT usLen );
+USHORT          usMBCRC16( const UCHAR * pucFrame, USHORT usLen );
 
 #endif

--- a/modbus/rtu/mbrtu.c
+++ b/modbus/rtu/mbrtu.c
@@ -149,7 +149,6 @@ eMBRTUStop( void )
 eMBErrorCode
 eMBRTUReceive( UCHAR * pucRcvAddress, UCHAR ** pucFrame, USHORT * pusLength )
 {
-    BOOL            xFrameReceived = FALSE;
     eMBErrorCode    eStatus = MB_ENOERR;
 
     ENTER_CRITICAL_SECTION(  );
@@ -171,7 +170,6 @@ eMBRTUReceive( UCHAR * pucRcvAddress, UCHAR ** pucFrame, USHORT * pusLength )
 
         /* Return the start of the Modbus PDU to the caller. */
         *pucFrame = ( UCHAR * ) & ucRTUBuf[MB_SER_PDU_PDU_OFF];
-        xFrameReceived = TRUE;
     }
     else
     {


### PR DESCRIPTION
A fix for several trivial compiler warnings. Environment: Keil MDK with -Wall enabled.