### PR TITLE
Volatile qualifier added for bare metal portevent.c static variables

### DIFF
--- a/demo/ATSAM3S/port/portevent.c
+++ b/demo/ATSAM3S/port/portevent.c
@@ -33,8 +33,8 @@
 #include "mbport.h"
 
 /* ----------------------- Variables ----------------------------------------*/
-static eMBEventType eQueuedEvent;
-static BOOL     xEventInQueue;
+static volatile eMBEventType eQueuedEvent;
+static volatile BOOL     xEventInQueue;
 
 /* ----------------------- Start implementation -----------------------------*/
 BOOL

--- a/demo/AVR/port/portevent.c
+++ b/demo/AVR/port/portevent.c
@@ -24,8 +24,8 @@
 #include "mbport.h"
 
 /* ----------------------- Variables ----------------------------------------*/
-static eMBEventType eQueuedEvent;
-static BOOL     xEventInQueue;
+static volatile eMBEventType eQueuedEvent;
+static volatile BOOL     xEventInQueue;
 
 /* ----------------------- Start implementation -----------------------------*/
 BOOL

--- a/demo/AVR2560/port/portevent.c
+++ b/demo/AVR2560/port/portevent.c
@@ -24,8 +24,8 @@
 #include "mbport.h"
 
 /* ----------------------- Variables ----------------------------------------*/
-static eMBEventType eQueuedEvent;
-static BOOL     xEventInQueue;
+static volatile eMBEventType eQueuedEvent;
+static volatile BOOL     xEventInQueue;
 
 /* ----------------------- Start implementation -----------------------------*/
 BOOL

--- a/demo/BARE/port/portevent.c
+++ b/demo/BARE/port/portevent.c
@@ -24,8 +24,8 @@
 #include "mbport.h"
 
 /* ----------------------- Variables ----------------------------------------*/
-static eMBEventType eQueuedEvent;
-static BOOL     xEventInQueue;
+static volatile eMBEventType eQueuedEvent;
+static volatile BOOL     xEventInQueue;
 
 /* ----------------------- Start implementation -----------------------------*/
 BOOL

--- a/demo/HCS08/port/portevent.c
+++ b/demo/HCS08/port/portevent.c
@@ -24,8 +24,8 @@
 #include "mbport.h"
 
 /* ----------------------- Variables ----------------------------------------*/
-static eMBEventType eQueuedEvent;
-static BOOL     xEventInQueue;
+static volatile eMBEventType eQueuedEvent;
+static volatile BOOL     xEventInQueue;
 
 /* ----------------------- Start implementation -----------------------------*/
 BOOL

--- a/demo/LPC214X/port/portevent.c
+++ b/demo/LPC214X/port/portevent.c
@@ -24,8 +24,8 @@
 #include "mbport.h"
 
 /* ----------------------- Variables ----------------------------------------*/
-static eMBEventType eQueuedEvent;
-static BOOL     xEventInQueue;
+static volatile eMBEventType eQueuedEvent;
+static volatile BOOL     xEventInQueue;
 
 /* ----------------------- Start implementation -----------------------------*/
 BOOL

--- a/demo/MCF5235/port/portevent.c
+++ b/demo/MCF5235/port/portevent.c
@@ -25,8 +25,8 @@
 #include "mbport.h"
 
 /* ----------------------- Variables ----------------------------------------*/
-static eMBEventType eQueuedEvent;
-static BOOL     xEventInQueue;
+static volatile eMBEventType eQueuedEvent;
+static volatile BOOL     xEventInQueue;
 
 /* ----------------------- Start implementation -----------------------------*/
 BOOL

--- a/demo/MCF5235CW/port/portevent.c
+++ b/demo/MCF5235CW/port/portevent.c
@@ -25,8 +25,8 @@
 #include "mbport.h"
 
 /* ----------------------- Variables ----------------------------------------*/
-static eMBEventType eQueuedEvent;
-static BOOL     xEventInQueue;
+static volatile eMBEventType eQueuedEvent;
+static volatile BOOL     xEventInQueue;
 
 /* ----------------------- Start implementation -----------------------------*/
 BOOL

--- a/demo/MSP430/port/portevent.c
+++ b/demo/MSP430/port/portevent.c
@@ -24,8 +24,8 @@
 #include "mbport.h"
 
 /* ----------------------- Variables ----------------------------------------*/
-static eMBEventType eQueuedEvent;
-static BOOL     xEventInQueue;
+static volatile eMBEventType eQueuedEvent;
+static volatile BOOL     xEventInQueue;
 
 /* ----------------------- Start implementation -----------------------------*/
 BOOL

--- a/demo/Z8ENCORE/port/portevent.c
+++ b/demo/Z8ENCORE/port/portevent.c
@@ -24,8 +24,8 @@
 #include "mbport.h"
 
 /* ----------------------- Variables ----------------------------------------*/
-static eMBEventType eQueuedEvent;
-static BOOL     xEventInQueue;
+static volatile eMBEventType eQueuedEvent;
+static volatile BOOL     xEventInQueue;
 
 /* ----------------------- Start implementation -----------------------------*/
 BOOL


### PR DESCRIPTION
This PR is addressing my original issue #38. While integrating bare metal code, with -O3 -flto GCC optimization settings, both AVR and ARM architectures refused to receive Modbus RTU requests. Debugging discovered that eQueuedEvent and xEventInQueue were optimized and was not tested upon an event.
This behavior of original code is correct for ANSI C - the compiler can optimize the variables which are not changed in current context. But in portevent.c both variables are accessed from a function which is called from an interrupt - which is out of compiler context. So in portevent.c both variables, eQueuedEvent and xEventInQueue, should be defined as volatile. This is exactly the case for which the qualifier is designed.

In this PR I added volatile qualifier to all bare metal instances of portevent.c. Other places where variables are used inside of freertos, Linux or Windows are intact. I have not enough experience to judge if the same modification is needed when operational system is used.