### PR TITLE
UART TX complete conditional compile

### DIFF
--- a/modbus/rtu/mbrtu.c
+++ b/modbus/rtu/mbrtu.c
@@ -376,10 +376,15 @@ xMBRTUTransmitFSM( void )
         else
         {
             xNeedPoll = xMBPortEventPost( EV_FRAME_SENT );
+#ifdef MB_TX_COMPLETE_EMPTY
+            /* Optionally disable this as the final character MAY STILL SENDING when this is raised
+             * Instead use the STATE_TX_IDLE when next called on TX_COMPLETE when needed */
+#else
             /* Disable transmitter. This prevents another transmit buffer
              * empty interrupt. */
             vMBPortSerialEnable( TRUE, FALSE );
             eSndState = STATE_TX_IDLE;
+#endif
         }
         break;
     }


### PR DESCRIPTION
Releasing of the bus may need handling differently depending on UART ISR behaviour.
For example, Renesas RA2L1 would prevent the final byte from being sent