### PR TITLE
Fix assertion in eMBRTUReceive

### DIFF
--- a/modbus/rtu/mbrtu.c
+++ b/modbus/rtu/mbrtu.c
@@ -153,7 +153,7 @@ eMBRTUReceive( UCHAR * pucRcvAddress, UCHAR ** pucFrame, USHORT * pusLength )
     eMBErrorCode    eStatus = MB_ENOERR;
 
     ENTER_CRITICAL_SECTION(  );
-    assert( usRcvBufferPos < MB_SER_PDU_SIZE_MAX );
+    assert( usRcvBufferPos <= MB_SER_PDU_SIZE_MAX );
 
     /* Length and CRC check */
     if( ( usRcvBufferPos >= MB_SER_PDU_SIZE_MIN )


### PR DESCRIPTION
* Fixes #33 
* Having a completely filled receive buffer is no issue per se
* This check should accept a full buffer
    * Check for receive buffer write position in [`xMBRTUReceiveFSM`](https://github.com/cwalter-at/freemodbus/blob/eac737c58e2e81b72d8f83c7eb19dcf8d7e1e9ae/modbus/rtu/mbrtu.c#L326) before storing received byte
    * [Updating the receive buffer write position](https://github.com/cwalter-at/freemodbus/blob/eac737c58e2e81b72d8f83c7eb19dcf8d7e1e9ae/modbus/rtu/mbrtu.c#L339) after the previous check was successful
        * The buffer may now be full:  `usRcvBufferPos == MB_SER_PDU_SIZE_MAX`
    * Overly eager check in [`eMBRTUReceive`](https://github.com/cwalter-at/freemodbus/blob/eac737c58e2e81b72d8f83c7eb19dcf8d7e1e9ae/modbus/rtu/mbrtu.c#L157) when processing buffer data will trip an assertion in this function and might cause the application to abort
        * The buffer write position got already updated at this point in time
        * Refusing to process the already stored data in case of a full buffer is wrong as the buffer's size is [`MB_SER_PDU_SIZE_MAX`](https://github.com/cwalter-at/freemodbus/blob/eac737c58e2e81b72d8f83c7eb19dcf8d7e1e9ae/modbus/rtu/mbrtu.c#L71)
* This situation can be reproduced which dense Modbus/RTU traffic with log telegrams for other units on the bus, so that the receive buffer gets filled up