### PR TITLE
(Fix) An inconsistency bug that leads demo/LINUXTCP to crash -- Violation of MODBUS/TCP PDU size

### DIFF
--- a/demo/LINUXTCP/port/porttcp.c
+++ b/demo/LINUXTCP/port/porttcp.c
@@ -220,6 +220,11 @@ xMBPortTCPPool( void )
         {
             if( FD_ISSET( xClientSocket, &fread ) )
             {
+                if (usTCPFrameBytesLeft > MB_TCP_BUF_SIZE) {//Received PDU exceeds the maximum size: 256 + 7 bytes
+                    close(xClientSocket);
+                    xClientSocket = INVALID_SOCKET;
+                    return TRUE;
+                }
                 if( ( ( ret =
                         recv( xClientSocket, &aucTCPBuf[usTCPBufPos], usTCPFrameBytesLeft,
                               0 ) ) == SOCKET_ERROR ) || ( !ret ) )


### PR DESCRIPTION
- Fix: [#63  An inconsistency bug that leads demo/LINUXTCP to crash -- Violation of MODBUS/TCP PDU size](https://github.com/cwalter-at/freemodbus/issues/63)
- To address this issue, we have implemented a mechanism to check the PDU length of received messages, preventing buffer overflow in `demo/LINUXTCP`. 