### PR TITLE
(Fix) A Bug Causing FreeModbus Server Hang Due to Protocol Identifier Violation

### DIFF
--- a/modbus/tcp/mbtcp.c
+++ b/modbus/tcp/mbtcp.c
@@ -124,6 +124,10 @@ eMBTCPReceive( UCHAR * pucRcvAddress, UCHAR ** ppucFrame, USHORT * pusLength )
              */
             *pucRcvAddress = MB_TCP_PSEUDO_ADDRESS;
         }
+        else
+        {
+            assert(usPID == MB_TCP_PROTOCOL_ID);
+        }
     }
     else
     {

--- a/modbus/tcp/mbtcp.c
+++ b/modbus/tcp/mbtcp.c
@@ -30,6 +30,8 @@
 /* ----------------------- System includes ----------------------------------*/
 #include "stdlib.h"
 #include "string.h"
+#include "unistd.h"
+#include "stdio.h"
 
 /* ----------------------- Platform includes --------------------------------*/
 #include "port.h"
@@ -40,6 +42,8 @@
 #include "mbtcp.h"
 #include "mbframe.h"
 #include "mbport.h"
+
+extern SOCKET xClientSocket;
 
 #if MB_TCP_ENABLED > 0
 
@@ -126,7 +130,9 @@ eMBTCPReceive( UCHAR * pucRcvAddress, UCHAR ** ppucFrame, USHORT * pusLength )
         }
         else
         {
-            assert(usPID == MB_TCP_PROTOCOL_ID);
+            // assert(usPID == MB_TCP_PROTOCOL_ID);
+            close(xClientSocket);
+            xClientSocket = INVALID_SOCKET;
         }
     }
     else


### PR DESCRIPTION
- Fix: [#62  A Bug Causing FreeModbus Server Hang Due to Protocol Identifier Violation](https://github.com/cwalter-at/freemodbus/issues/62)
- To address this issue, we have added an assertion statement to alert on unexpected protocol identifiers and prevent the system from hanging.