### PR TITLE
Fix writing multiple holding registers (MBRTU)

### DIFF
--- a/modbus/functions/mbfuncholding.c
+++ b/modbus/functions/mbfuncholding.c
@@ -128,7 +128,8 @@ eMBFuncWriteMultipleHoldingRegister( UCHAR * pucFrame, USHORT * usLen )
 
         if( ( usRegCount >= 1 ) &&
             ( usRegCount <= MB_PDU_FUNC_WRITE_MUL_REGCNT_MAX ) &&
-            ( ucRegByteCount == ( UCHAR ) ( 2 * usRegCount ) ) )
+            ( ucRegByteCount == ( UCHAR ) ( 2 * usRegCount ) ) &&
+            ( ucRegByteCount == ( UCHAR ) ( *usLen - MB_PDU_SIZE_MIN - MB_PDU_FUNC_WRITE_MUL_SIZE_MIN ) ) )
         {
             /* Make callback to update the register values. */
             eRegStatus =


### PR DESCRIPTION
It is necessary to check the actual number of bytes received to avoid writing "garbage".

An example of wrong behavior (hex):
req: `0A 10 0001 0003 06 0A0B0C EE98` **<- WRONG REQUEST**
res: `0A 10 0001 0003 D0B3`
req: `0A 03 0000 0004 4572`
res: `0A 03 08 0000 0A0B 0CEE 9800 1D3D`
Here we have a wrong request with a correct CRC that executes without errors, but we got the CRC bytes written to the holding registers.

In order to fix this behavior I suggest checking the number of bytes actually received.
In this case we got:
req: `0A 10 0001 0003 06 0A0B0C EE98`
res: `0A 90 03 7DC3`

I tested this on my Arch Linux and also on a Cortex-M3 MCU.