### PR TITLE
Suppress compiler warning for unused ucRefType variable

### DIFF
--- a/modbus/functions/mbfuncfile.c
+++ b/modbus/functions/mbfuncfile.c
@@ -89,6 +89,7 @@ eMBFuncWriteFileRecord( UCHAR * pucFrame, USHORT * usLen )
         usFileRecLen = ( USHORT )( pucFrame[MB_PDU_FUNC_FILE_REC_LEN_OFF] << 8 );
         usFileRecLen |= ( USHORT )( pucFrame[MB_PDU_FUNC_FILE_REC_LEN_OFF + 1] );
 
+        (void)ucRefType;
         usFileByteLen = usFileRecLen * 2;
 
         /* TODO - allow multiple writes per request (as per spec) */


### PR DESCRIPTION
Removing compiler warning on compilation:

`modbus/functions/mbfuncfile.c:73:21: warning: variable 'ucRefType' set but not used [-Wunused-but-set-variable]`