### PR TITLE
Wrong #endif position in xMBRTUTransmitFSM for MB_TX_COMPLETE_EMPTY

### DIFF
--- a/modbus/rtu/mbrtu.c
+++ b/modbus/rtu/mbrtu.c
@@ -383,8 +383,8 @@ xMBRTUTransmitFSM( void )
             /* Disable transmitter. This prevents another transmit buffer
              * empty interrupt. */
             vMBPortSerialEnable( TRUE, FALSE );
-            eSndState = STATE_TX_IDLE;
 #endif
+            eSndState = STATE_TX_IDLE;
         }
         break;
     }


### PR DESCRIPTION
## Problem

In the `MB_TX_COMPLETE_EMPTY` build configuration, there is an incorrect `#endif` directive placement in the `xMBRTUTransmitFSM()` function. This causes the `STATE_TX_IDLE` state to never be reached in this code path.

## Changes

Moved the `eSndState = STATE_TX_IDLE;` assignment from inside the `#ifdef MB_TX_COMPLETE_EMPTY` conditional block to execute unconditionally after the block.

### Before:
```c
#ifdef MB_TX_COMPLETE_EMPTY
    /* Optionally disable this as the final character MAY STILL SENDING... */
#else
    vMBPortSerialEnable( TRUE, FALSE );
    eSndState = STATE_TX_IDLE;  // ← This code was INSIDE #endif
#endif
```

### After:
```c
#ifdef MB_TX_COMPLETE_EMPTY
    /* Optionally disable this as the final character MAY STILL SENDING... */
#else
    vMBPortSerialEnable( TRUE, FALSE );
#endif
eSndState = STATE_TX_IDLE;  // ← Now executes AFTER #endif
```

## Root Cause

When compiled with the `MB_TX_COMPLETE_EMPTY` flag defined, the `#else` block is excluded from the build, but the `#endif` was incorrectly positioned before the state assignment. This meant that in the `MB_TX_COMPLETE_EMPTY` configuration, the transmitter state was never reset to `STATE_TX_IDLE`, leaving the FSM (Finite State Machine) in an invalid state.

## Impact

- **Files Changed:** 1 (`modbus/rtu/mbrtu.c`)
- **Lines Added:** 1
- **Lines Deleted:** 1
- **Change Type:** 🐛 Critical FSM logic fix
- **Safety:** Safe for all configurations

## Tested and In Production

This fix has been tested and validated in production with the following implementation:

**Project:** [Spider84/Handle](https://github.com/Spider84/Handle) - N32G430 microcontroller with FreeModbus RTU

**Configuration:** `MB_TX_COMPLETE_EMPTY` enabled for RS485 transmission with proper interrupt sequencing

**Implementation Details:**
- Serial port driver: [`src/mb_port/portserial.c`](https://github.com/Spider84/Handle/blob/6f62883967eee3ad06d533242e04bf797199a9a7/src/mb_port/portserial.c)
- Transmission complete interrupt handler: [Lines 201-213](https://github.com/Spider84/Handle/blob/6f62883967eee3ad06d533242e04bf797199a9a7/src/mb_port/portserial.c#L201)

**Verification:**
- FSM correctly transitions to `STATE_TX_IDLE` after transmission completes
- Transmitter properly switches to receiver mode (RTS control for RS485)
- No data loss or protocol corruption in production
- Interrupt sequencing works correctly: `TXDE → TXC → STATE_TX_IDLE`